### PR TITLE
Fixed File Scrolling Issue On Timeline Page

### DIFF
--- a/src/components/Files/index.js
+++ b/src/components/Files/index.js
@@ -57,9 +57,11 @@ export default function Files({ pr, repo, className }) {
         getPRFiles({repo, prNumber: pr.number})
             .then(setDiff)
             .then(() => {
-                const elements = document.getElementsByName(location.hash.substring(1)); // Remove hash
+                if (location.hash) {
+                    const elements = document.getElementsByName(location.hash.substring(1)); // Remove hash
 
-                if (elements.length === 1) elements[0].parentElement.scrollIntoView();
+                    if (elements.length === 1) elements[0].parentElement.scrollIntoView();
+                }
             })
             .catch(error => {
                 console.log(error);

--- a/src/components/Files/index.js
+++ b/src/components/Files/index.js
@@ -52,13 +52,20 @@ export default function Files({ pr, repo, className }) {
   const [ collapsed, collapse ] = useReducer(expandedReducer, []);
   const [ toComment, openComment ] = useReducer(toCommentReducer, []);
 
-  useEffect(() => {
-    setDiff(null);
-    getPRFiles({ repo, prNumber: pr.number }).then(setDiff, error => {
-      console.log(error);
-      setError(error);
-    });
-  }, [ pr.id ]);
+    useEffect(() => {
+        setDiff(null);
+        getPRFiles({repo, prNumber: pr.number})
+            .then(setDiff)
+            .then(() => {
+                const elements = document.getElementsByName(location.hash.substring(1)); // Remove hash
+
+                if (elements.length === 1) elements[0].parentElement.scrollIntoView();
+            })
+            .catch(error => {
+                console.log(error);
+                setError(error);
+            });
+    }, [pr.id]);
 
   if (error) {
     return (

--- a/src/components/FilesPreview.js
+++ b/src/components/FilesPreview.js
@@ -4,23 +4,31 @@ import PropTypes from 'prop-types';
 
 import { CHEVRON_RIGHT, CHEVRON_DOWN } from './Icons';
 import Diff from './utils/Diff';
+import { Link } from 'react-router-dom';
 
 const INDENT_STEP = 4;
 
-function Directory({ dir, indent }) {
+function Directory({ dir, indent, url }) {
   const isFile = dir.items === null;
+
+  const inFileView = url.match(/\/files$/) !== null;
 
   return (
     <div style={ { paddingLeft: `${ indent }px` } } className={ isFile ? 'is-file' : 'is-dir' }>
-      { isFile ? <a href={ `#${ dir.fullPath }` }>{ dir.path }</a> : dir.path }
+      { !isFile ?
+          dir.path :
+          inFileView ?
+              <a href={ `#${ dir.fullPath }` }>{ dir.path }</a> :
+              <Link to={ `${url}/files#${ dir.fullPath }` }>{ dir.path }</Link>
+      }
       { isFile ?
         <Diff data={ { additions: dir.additions, deletions: dir.deletions } } /> : '' }
-      { !isFile && dir.items.map(item => <Directory dir={ item } indent={ indent + INDENT_STEP } key={ item.path }/>)}
+      { !isFile && dir.items.map(item => <Directory url={ url } dir={ item } indent={ indent + INDENT_STEP } key={ item.path }/>)}
     </div>
   );
 }
 
-export default function FilesPreview({ pr }) {
+export default function FilesPreview({ pr, url }) {
   const [ expanded, expand ] = useState(false);
 
   return (
@@ -33,7 +41,7 @@ export default function FilesPreview({ pr }) {
         expanded && (
           <div className='pl1 bl1 ml1 files-preview'>
             {
-              pr.files.tree.items.map(item => <Directory dir={ item } indent={ INDENT_STEP } key={ item.path } />)
+              pr.files.tree.items.map(item => <Directory url={ url } dir={ item } indent={ INDENT_STEP } key={ item.path } />)
             }
           </div>
         )

--- a/src/components/PR.js
+++ b/src/components/PR.js
@@ -48,6 +48,8 @@ export default function PR({ url, pr, repo }) {
 
   const [ base, head ] = formatBranchLabels(pr.base, pr.head);
 
+  const nonNormalizedUrl = url;
+
   url = normalizeURL(url);
 
   return (
@@ -73,7 +75,7 @@ export default function PR({ url, pr, repo }) {
         <div className='markdown mt1' dangerouslySetInnerHTML={ { __html: marked(pr.body, repo) } } />
         { (!pr.merged && !pr.closed) && <PROps pr={ pr } repo={ repo }/> }
         <Reviewers pr={ pr }/>
-        <FilesPreview pr={ pr } />
+        <FilesPreview pr={ pr } url={ nonNormalizedUrl } />
       </div>
       <Switch>
         <Route path={ url + '/files' } render={ () => (


### PR DESCRIPTION
Changes to fix an issue that prevents the window from scrolling to a changed file when the "Files" tab is not opened.

This additionally adds the ability to share links to specific files via the anchor.

Issue: #2 