### PR TITLE
fix bug causing 'Parse error on "-"'

### DIFF
--- a/src/api/graphql.js
+++ b/src/api/graphql.js
@@ -302,7 +302,7 @@ export const QUERY_GET_PRS = (name, owner, perPage, cursor) => `{
 
 export const QUERY_GET_PR = (name, owner, prNumber) => `
   query {
-    repository(name: "${ name }", owner: ${ owner }) {
+    repository(name: "${ name }", owner: "${ owner }") {
       name,
       owner {
           login
@@ -316,7 +316,7 @@ export const QUERY_GET_PR = (name, owner, prNumber) => `
 
 export const QUERY_GET_PR_STATUSES = (prNumber, name, owner) => `
   query {
-    repository(name: "${ name }", owner: ${ owner }) {
+    repository(name: "${ name }", owner: "${ owner }") {
       name,
       owner {
         login


### PR DESCRIPTION
Repositories owned by user/organization names with a hyphen in the name cannot be queried without quoting the owner. Thereby, I've added quotes to fix the issue.